### PR TITLE
[NWPS-1348] - Card--downloads tidy up 

### DIFF
--- a/app/assets/hee/blocks/content/sidebar/card--downloads/README.md
+++ b/app/assets/hee/blocks/content/sidebar/card--downloads/README.md
@@ -1,0 +1,108 @@
+# Card: Downloads
+This component is a sidebar based card, displaying links and filetypes to downloads in an unordered list.
+
+## Dependencies
+The filetypes in this component are inherited from the `hee-resources` component, and supports the following extenstions:
+
+- pdf
+- doc
+- docx
+- xls
+- xlsx
+- csv
+- txt
+- odt
+- ott
+- fodt
+- ods
+- odt
+- fodp
+- oth
+- odg
+- fodg
+- otg
+- odb
+- fodb
+- otg
+
+## Quick start example
+
+[Preview this component](https://health-education-england.github.io/hee-prototypes/blocks/content/sidebar-card-downloads.html)
+
+### HTML markup
+
+````html
+<div class="hee-card hee-card--details hee-card--downloads">
+    <h3>Alternative versions</h3>
+    <div class="hee-card--details__item">
+      <a class="hee-resources__link" href="#" title="Publication title - PDF version">
+        <span class="hee-resources__text">Publication title - PDF version</span>
+        <span class="hee-resources__tag hee-resources__pdf">PDF</span>
+      </a>
+    </div>
+    <div class="hee-card--details__item">
+      <a class="hee-resources__link" href="#" title="Publication title - Open Document">
+        <span class="hee-resources__text">Publication title - Open Document</span>
+        <span class="hee-resources__tag hee-resources__odf">ODF</span>
+      </a>
+    </div>
+    <div class="hee-card--details__item">
+      <a class="hee-resources__link" href="#" title="Publication title - Excel">
+        <span class="hee-resources__text">Publication title - Excel</span>
+        <span class="hee-resources__tag hee-resources__xls">XLS</span>
+      </a>
+    </div>
+</div>
+````
+
+---
+
+#### Nunjucks macro
+
+````
+{%- from 'hee/blocks/content/sidebar/card--downloads/macro.njk' import downloadsCard %}
+
+{{ downloadsCard({
+  title: "Alternative versions",
+  items: [
+    {
+      title: "Publication title - PDF version",
+      text: "Publication title - PDF version",
+      url: "https://www.google.com",
+      docType: "PDF",
+      tagColor: "pdf",
+    },
+    {
+      title: "Publication title - Open Document",
+      text: "Publication title - Open Document",
+      url: "https://www.google.com",
+      docType: "ODF",
+      tagColor: "odf",
+    },
+    {
+      title: "Publication title - Excel",
+      text: "Publication title - Excel",
+      url: "https://www.google.com",
+      docType: "XLS",
+      tagColor: "xls",
+    }        
+  ]
+}) }}
+````
+
+---
+
+### Nunjucks arguments
+
+Macro takes the following arguments:
+
+| Name              | Type   | Required  | Description                                              |
+|-------------------|--------|-----------|----------------------------------------------------------|
+| title             | string | Yes       | Text displayed as card title                             |
+| items             | array  | Yes       | Array of download items                                  |
+| items[].title     | string | Yes       | Link title for the download                              |
+| items[].text      | string | Yes       | Link text displayed for download                         |
+| items[].url       | string | Yes       | Link href property                                       |
+| items[].docType   | string | Yes       | Download extension displayed in lozenge                  |
+| items[].tagColor  | string | Yes       | Colour of lozenge derived from `hee-resources` component |
+  

--- a/app/assets/hee/blocks/content/sidebar/card--downloads/_downloads.scss
+++ b/app/assets/hee/blocks/content/sidebar/card--downloads/_downloads.scss
@@ -1,0 +1,29 @@
+// Card downloads
+.hee-card--downloads {
+  .hee-resources__link {
+    align-content: flex-start;
+    align-items: flex-start;
+    display: flex;
+    text-decoration: none;
+
+    span {
+      font-weight: normal;
+
+      &.hee-resources__text {
+        display: block;
+        text-decoration: underline;
+        width: 80%;
+      }
+
+      &.hee-resources__tag {
+        border-radius: 6px;
+        font-size: 10px;
+        margin: 0;
+        min-width: 32px;
+        padding: 2px 6px 0 6px;
+        text-decoration: none;
+        top: 4px;
+      }
+    }
+  }
+}

--- a/app/assets/hee/blocks/content/sidebar/card--downloads/marco.njk
+++ b/app/assets/hee/blocks/content/sidebar/card--downloads/marco.njk
@@ -1,0 +1,18 @@
+{%- from 'components/hee/hee-resources/macro.njk' import resources %}
+
+{% macro downloadsCard(params) %}
+<div class="hee-card hee-card--details hee-card--downloads">
+  <h3>{{ params.title }}</h3>
+  {% for item in params.items %}
+    <div class="hee-card--details__item">
+      {{ resources({
+        title: item.title,
+        text: item.text,
+        url: item.url,
+        docType: item.docType,
+        tagColor: item.tagColor
+      }) }}
+    </div>
+  {% endfor %}
+</div>
+{% endmacro %}

--- a/app/views/blocks/content/examples/sidebar-card-downloads.html
+++ b/app/views/blocks/content/examples/sidebar-card-downloads.html
@@ -1,0 +1,30 @@
+{% extends "example-blocks.html" %}
+
+{% block main %}
+  {{ downloadsCard({
+    title: "Alternative versions",
+    items: [
+      {
+        title: "Publication title - PDF version",
+        text: "Publication title - PDF version",
+        url: "#",
+        docType: "PDF",
+        tagColor: "pdf"
+      },
+      {
+        title: "Publication title - Open Document",
+        text: "Publication title - Open Document",
+        url: "#",
+        docType: "ODF",
+        tagColor: "odf"
+      },
+      {
+        title: "Publication title - Excel",
+        text: "Publication title - Excel",
+        url: "#",
+        docType: "XLS",
+        tagColor: "xls"
+      }
+    ]
+  }) }}
+{% endblock %}

--- a/app/views/blocks/content/sidebar-card-downloads.html
+++ b/app/views/blocks/content/sidebar-card-downloads.html
@@ -1,0 +1,121 @@
+{% extends "prototype-inner.html" %}
+
+{% set page_url = 'sidebar-card-downloads' %}
+{% set page_title = 'Card--Downloads' %}
+
+{% block pageTitle %}{{ page_title }} - Templates - NWP Prototype Kit{% endblock %}
+
+{% block breadcrumbs %}
+{{ 
+    breadcrumb({
+    items: [
+        {
+            href: basePath + "/",
+            text: "Home"
+        },
+        {
+            href: basePath + "/blocks",
+            text: "Blocks"
+        },
+        {
+            href: basePath + "/blocks/content",
+            text: "Content"
+        }
+    ],
+        href: basePath + "/blocks/"+page_url,
+      text: page_title
+    }) 
+}}
+{% endblock %}
+
+{% block pageLeftbar %}
+{{ subnav({
+    area: 'blocks',
+    subarea: 'content'
+}) }}
+{% endblock %}
+
+{% block pageHeader %}
+    <span class="nhsuk-caption-xl">Main</span>
+    <h1>{{ page_title }}</h1>
+    <p class="nhsuk-lede-text"></p>
+{% endblock %}
+
+{% block pageContent %}
+
+<p>Card displaying link of download resource links including their file types.</p>
+
+<h3>Example</h3>
+{{ example({
+    view: 'block',
+    url: basePath + '/blocks/content/examples/' + page_url,
+    height: '380'
+}) }}
+
+<hr />
+
+<h3>Macro</h3>
+{{ highlight({
+  html: '
+{{ downloadsCard({
+  title: "Alternative versions",
+  items: [
+    {
+      title: "Publication title - PDF version",
+      text: "Publication title - PDF version",
+      url: "https://www.google.com",
+      docType: "PDF",
+      tagColor: "pdf",
+    },
+    {
+      title: "Publication title - Open Document",
+      text: "Publication title - Open Document",
+      url: "https://www.google.com",
+      docType: "ODF",
+      tagColor: "odf",
+    },
+    {
+      title: "Publication title - Excel",
+      text: "Publication title - Excel",
+      url: "https://www.google.com",
+      docType: "XLS",
+      tagColor: "xls",
+    }
+  ]
+}) }}
+  '
+}) }}
+
+<hr />
+
+<h3>HTML</h3>
+{{ highlight({
+  html : '
+<div class="hee-card hee-card--details hee-card--downloads">
+    <h3>Alternative versions</h3>
+    <div class="hee-card--details__item">
+      <a class="hee-resources__link" href="#" title="Publication title - PDF version">
+        <span class="hee-resources__text">Publication title - PDF version</span>
+        <span class="hee-resources__tag hee-resources__pdf">PDF</span>
+      </a>
+    </div>
+    <div class="hee-card--details__item">
+      <a class="hee-resources__link" href="#" title="Publication title - Open Document">
+        <span class="hee-resources__text">Publication title - Open Document</span>
+        <span class="hee-resources__tag hee-resources__odf">ODF</span>
+      </a>
+    </div>
+    <div class="hee-card--details__item">
+      <a class="hee-resources__link" href="#" title="Publication title - Excel">
+        <span class="hee-resources__text">Publication title - Excel</span>
+        <span class="hee-resources__tag hee-resources__xls">XLS</span>
+      </a>
+    </div>
+</div>
+  '
+  }) 
+}}
+
+{% endblock %}
+
+{% block pageFooter %}{% endblock %}

--- a/app/views/example.html
+++ b/app/views/example.html
@@ -42,6 +42,7 @@
 {# Sidebar #}
 {%- from 'hee/blocks/content/sidebar/card--details/macro.njk' import detailsCard %}
 {%- from 'hee/blocks/content/sidebar/card--cta/macro.njk' import ctaCard %}
+{%- from 'hee/blocks/content/sidebar/card--downloads/marco.njk' import downloadsCard %}
 
 {# To Sort #}
 {# HEE Components #}

--- a/app/views/includes/_globals.html
+++ b/app/views/includes/_globals.html
@@ -222,7 +222,7 @@
       {
         title: 'Card--Downloads',
         url: 'sidebar-card-downloads',
-        status: 'To Do'
+        status: 'Done'
       },
       {
         title: 'Card--External Links',

--- a/app/views/templates/examples/publications-item.html
+++ b/app/views/templates/examples/publications-item.html
@@ -211,79 +211,49 @@
     ]
   }) }}
 
-  {% set pdf %}
-    {{ resources({
-      title: "Publication title - PDF version",
-      text: "Publication title - PDF version",
-      url: "#",
-      docType: "PDF",
-      tagColor: "pdf"
-    }) }}
-  {% endset %}
-
-  {% set odf %}
-    {{ resources({
-      title: "Publication title - Open Document",
-      text: "Publication title - Open Document",
-      url: "#",
-      docType: "ODF",
-      tagColor: "odf"
-    }) }}
-  {% endset %}
-
-  {% set xls %}
-    {{ resources({
-      title: "Publication title - Excel",
-      text: "Publication title - Excel",
-      url: "#",
-      docType: "XLS",
-      tagColor: "xls"
-    }) }}
-  {% endset %}
-
-  {{ detailsCard({
+  {{ downloadsCard({
     title: "Alternative versions",
     items: [
       {
-        value: pdf
+        title: "Publication title - PDF version",
+        text: "Publication title - PDF version",
+        url: "#",
+        docType: "PDF",
+        tagColor: "pdf"
       },
       {
-        value: odf
+        title: "Publication title - Open Document",
+        text: "Publication title - Open Document",
+        url: "#",
+        docType: "ODF",
+        tagColor: "odf"
       },
       {
-        value: xls
+        title: "Publication title - Excel",
+        text: "Publication title - Excel",
+        url: "#",
+        docType: "XLS",
+        tagColor: "xls"
       }
     ]
   }) }}
 
-  {% set firstLang %}
-    {{ resources({
-      title: "Teitl y cyhoeddiad - Fersiwn PDF",
-      text: "Teitl y cyhoeddiad - Fersiwn PDF",
-      url: "#",
-      docType: "PDF",
-      tagColor: "pdf"
-    }) }}
-  {% endset %}
-
-  {% set secondLang %}
-    {{ resources({
-      title: "Tytuł publikacji - wersja PDF",
-      text: "Tytuł publikacji - wersja PDF",
-      url: "#",
-      docType: "PDF",
-      tagColor: "pdf"
-    }) }}
-  {% endset %}
-
-  {{ detailsCard({
+  {{ downloadsCard({
     title: "Languages",
     items: [
       {
-        value: firstLang
+        title: "Teitl y cyhoeddiad - Fersiwn PDF",
+        text: "Teitl y cyhoeddiad - Fersiwn PDF",
+        url: "#",
+        docType: "PDF",
+        tagColor: "pdf"
       },
       {
-        value: secondLang
+        title: "Tytuł publikacji - wersja PDF",
+        text: "Tytuł publikacji - wersja PDF",
+        url: "#",
+        docType: "PDF",
+        tagColor: "pdf"
       }
     ]
   }) }}

--- a/dist/blocks/content/examples/sidebar-card-downloads.html
+++ b/dist/blocks/content/examples/sidebar-card-downloads.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="ie8" lang="en"><![endif]--><!--[if IE 9]><html class="ie9" lang="en"><![endif]--><!--[if gt IE 9]><!-->
+<html lang="en" style=""><!--<![endif]-->
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="description" content="">
+  <title>Examples</title>
+  <link href="https://www.nhs.uk/" rel="preconnect">
+  <link href="https://assets.nhs.uk/" rel="preconnect" crossorigin>
+  <link type="font/woff2" href="https://assets.nhs.uk/fonts/FrutigerLTW01-55Roman.woff2" rel="preload" as="font" crossorigin>
+  <link type="font/woff2" href="https://assets.nhs.uk/fonts/FrutigerLTW01-65Bold.woff2" rel="preload" as="font" crossorigin>
+  <link href="/hee-prototypes/css/nhsuk-4.1.0.min.css" rel="stylesheet" />
+  <link href="/hee-prototypes/css/hee.css" rel="stylesheet" />
+  <style>
+    .example {}
+
+    .example--template {}
+
+    .example--blocks {
+      padding: 1em;
+      background-color: #f0f4f5;
+    }
+  </style>
+  <link rel="shortcut icon" href="/hee-prototypes/favicons/favicon.ico" type="image/x-icon">
+  <link rel="apple-touch-icon" href="/hee-prototypes/favicons/apple-touch-icon-180x180.png">
+  <link rel="mask-icon" href="/hee-prototypes/favicons/favicon.svg" color="#005eb8">
+  <link rel="icon" sizes="192x192" href="/hee-prototypes/favicons/favicon-192x192.png">
+  <meta name="msapplication-TileImage" content="/hee-prototypes/favicons/mediumtile-144x144.png">
+  <meta name="msapplication-TileColor" content="#005eb8">
+  <meta name="msapplication-square70x70logo" content="/hee-prototypes/favicons/smalltile-70x70.png">
+  <meta name="msapplication-square150x150logo" content="/hee-prototypes/favicons/mediumtile-150x150.png">
+  <meta name="msapplication-wide310x150logo" content="/hee-prototypes/favicons/widetile-310x150.png">
+  <meta name="msapplication-square310x310logo" content="/hee-prototypes/favicons/largetile-310x310.png">
+</head>
+
+<body class="example example--blocks">
+  <script>
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+  </script>
+  <div class="breadcrumbs">
+  </div>
+  <div class="banners">
+  </div>
+  <div class="hee-card hee-card--details hee-card--downloads">
+    <h3>Alternative versions</h3>
+    <div class="hee-card--details__item">
+      <a class="hee-resources__link" href="#" title="Publication title - PDF version">
+        <span class="hee-resources__text">Publication title - PDF version</span><span class="hee-resources__tag
+          hee-resources__pdf"> PDF </span></a>
+    </div>
+    <div class="hee-card--details__item">
+      <a class="hee-resources__link" href="#" title="Publication title - Open Document">
+        <span class="hee-resources__text">Publication title - Open Document</span><span class="hee-resources__tag
+          hee-resources__odf"> ODF </span></a>
+    </div>
+    <div class="hee-card--details__item">
+      <a class="hee-resources__link" href="#" title="Publication title - Excel">
+        <span class="hee-resources__text">Publication title - Excel</span><span class="hee-resources__tag
+          hee-resources__xls"> XLS </span></a>
+    </div>
+  </div>
+  <script src="/hee-prototypes/js/jquery-3.3.1.min.js"></script>
+  <script src="/hee-prototypes/js/nhsuk.min.js"></script>
+  <script src="/hee-prototypes/js/hee.js"></script>
+</body>
+
+</html>

--- a/dist/blocks/content/featured-mini-listing.html
+++ b/dist/blocks/content/featured-mini-listing.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/index.html
+++ b/dist/blocks/content/index.html
@@ -101,7 +101,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/main-applies-to.html
+++ b/dist/blocks/content/main-applies-to.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/main-block-links.html
+++ b/dist/blocks/content/main-block-links.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/main-card-author.html
+++ b/dist/blocks/content/main-card-author.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/main-care-card.html
+++ b/dist/blocks/content/main-care-card.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/main-google-map.html
+++ b/dist/blocks/content/main-google-map.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/main-image.html
+++ b/dist/blocks/content/main-image.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/main-media-embed.html
+++ b/dist/blocks/content/main-media-embed.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/main-publication-doc.html
+++ b/dist/blocks/content/main-publication-doc.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/main-region-picker.html
+++ b/dist/blocks/content/main-region-picker.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/main-table.html
+++ b/dist/blocks/content/main-table.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/main-tabs.html
+++ b/dist/blocks/content/main-tabs.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/sidebar-card-cta.html
+++ b/dist/blocks/content/sidebar-card-cta.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/sidebar-card-department.html
+++ b/dist/blocks/content/sidebar-card-department.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/sidebar-card-downloads.html
+++ b/dist/blocks/content/sidebar-card-downloads.html
@@ -7,7 +7,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="description" content="">
-  <title>Card--Details - Templates - NWP Prototype Kit</title>
+  <title>Card--Downloads - Templates - NWP Prototype Kit</title>
   <link href="https://www.nhs.uk/" rel="preconnect">
   <link href="https://assets.nhs.uk/" rel="preconnect" crossorigin>
   <link type="font/woff2" href="https://assets.nhs.uk/fonts/FrutigerLTW01-55Roman.woff2" rel="preload" as="font" crossorigin>
@@ -60,9 +60,9 @@
           <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/hee-prototypes/">Home</a></li>
           <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/hee-prototypes/blocks">Blocks</a></li>
           <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/hee-prototypes/blocks/content">Content</a></li>
-          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/hee-prototypes/blocks/sidebar-card-details">Card--Details</a></li>
+          <li class="nhsuk-breadcrumb__item"><a class="nhsuk-breadcrumb__link" href="/hee-prototypes/blocks/sidebar-card-downloads">Card--Downloads</a></li>
         </ol>
-        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" href="/hee-prototypes/blocks/sidebar-card-details">Back to Card--Details</a></p>
+        <p class="nhsuk-breadcrumb__back"><a class="nhsuk-breadcrumb__backlink" href="/hee-prototypes/blocks/sidebar-card-downloads">Back to Card--Downloads</a></p>
       </div>
     </nav>
   </div>
@@ -117,59 +117,69 @@
         <div class="page__main">
           <div class="page__header">
             <span class="nhsuk-caption-xl">Main</span>
-            <h1>Card--Details</h1>
+            <h1>Card--Downloads</h1>
             <p class="nhsuk-lede-text"></p>
           </div>
-          <p>Card displaying a title and a list of labels and values on each new line.</p>
+          <p>Card displaying link of download resource links including their file types.</p>
           <h3>Example</h3>
           <div class="prototype__example block">
-            <a href="/hee-prototypes/blocks/content/examples/sidebar-card-details.html" target="_blank" class="prototype__example-link">Open this example in new window</a>
+            <a href="/hee-prototypes/blocks/content/examples/sidebar-card-downloads.html" target="_blank" class="prototype__example-link">Open this example in new window</a>
             <div class="thumbnail">
-              <iframe src="/hee-prototypes/blocks/content/examples/sidebar-card-details.html" height="380"></iframe>
+              <iframe src="/hee-prototypes/blocks/content/examples/sidebar-card-downloads.html" height="380"></iframe>
             </div>
           </div>
           <hr />
           <h3>Macro</h3>
           <pre><code>
-{{ detailsCard({
-    title: &quot;Publication Info&quot;,
-    items: [
-      {
-        label: &quot;Published:&quot;,
-        value: &quot;24 June 2022&quot;
-      },
-      {
-        label: &quot;Updated:&quot;,
-        value: &quot;24 July 2022&quot;
-      },
-      {
-        label: &quot;Topic:&quot;,
-        value: &quot;&lt;a href=&quot;#&quot;&gt;Profession 1&lt;/a&gt;, &lt;a href=&quot;#&quot;&gt;Topic 1&lt;/a&gt;&quot;
-      },
-      {
-        label: &quot;Estimated reading time:&quot;,
-        value: &quot;2 mins&quot;
-      }
-    ]
+{{ downloadsCard({
+  title: &quot;Alternative versions&quot;,
+  items: [
+    {
+      title: &quot;Publication title - PDF version&quot;,
+      text: &quot;Publication title - PDF version&quot;,
+      url: &quot;https://www.google.com&quot;,
+      docType: &quot;PDF&quot;,
+      tagColor: &quot;pdf&quot;,
+    },
+    {
+      title: &quot;Publication title - Open Document&quot;,
+      text: &quot;Publication title - Open Document&quot;,
+      url: &quot;https://www.google.com&quot;,
+      docType: &quot;ODF&quot;,
+      tagColor: &quot;odf&quot;,
+    },
+    {
+      title: &quot;Publication title - Excel&quot;,
+      text: &quot;Publication title - Excel&quot;,
+      url: &quot;https://www.google.com&quot;,
+      docType: &quot;XLS&quot;,
+      tagColor: &quot;xls&quot;,
+    }
+  ]
 }) }}
   </code></pre>
           <hr />
           <h3>HTML</h3>
           <pre><code>
-&lt;div class=&quot;hee-card hee-card--details&quot;&gt;
-    &lt;h3&gt;Publication Info&lt;/h3&gt;
+&lt;div class=&quot;hee-card hee-card--details hee-card--downloads&quot;&gt;
+    &lt;h3&gt;Alternative versions&lt;/h3&gt;
     &lt;div class=&quot;hee-card--details__item&quot;&gt;
-      &lt;span&gt;Published:&lt;/span&gt; 24 June 2022
+      &lt;a class=&quot;hee-resources__link&quot; href=&quot;#&quot; title=&quot;Publication title - PDF version&quot;&gt;
+        &lt;span class=&quot;hee-resources__text&quot;&gt;Publication title - PDF version&lt;/span&gt;
+        &lt;span class=&quot;hee-resources__tag hee-resources__pdf&quot;&gt;PDF&lt;/span&gt;
+      &lt;/a&gt;
     &lt;/div&gt;
     &lt;div class=&quot;hee-card--details__item&quot;&gt;
-      &lt;span&gt;Updated:&lt;/span&gt; 24 July 2022
+      &lt;a class=&quot;hee-resources__link&quot; href=&quot;#&quot; title=&quot;Publication title - Open Document&quot;&gt;
+        &lt;span class=&quot;hee-resources__text&quot;&gt;Publication title - Open Document&lt;/span&gt;
+        &lt;span class=&quot;hee-resources__tag hee-resources__odf&quot;&gt;ODF&lt;/span&gt;
+      &lt;/a&gt;
     &lt;/div&gt;
     &lt;div class=&quot;hee-card--details__item&quot;&gt;
-      &lt;span&gt;Topic:&lt;/span&gt;
-      &lt;a href=&quot;#&quot;&gt;Profession 1&lt;/a&gt;, &lt;a href=&quot;#&quot;&gt;Topic 1&lt;/a&gt;
-    &lt;/div&gt;
-    &lt;div class=&quot;hee-card--details__item&quot;&gt;
-      &lt;span&gt;Estimated reading time:&lt;/span&gt; 2 mins
+      &lt;a class=&quot;hee-resources__link&quot; href=&quot;#&quot; title=&quot;Publication title - Excel&quot;&gt;
+        &lt;span class=&quot;hee-resources__text&quot;&gt;Publication title - Excel&lt;/span&gt;
+        &lt;span class=&quot;hee-resources__tag hee-resources__xls&quot;&gt;XLS&lt;/span&gt;
+      &lt;/a&gt;
     &lt;/div&gt;
 &lt;/div&gt;
   </code></pre>

--- a/dist/blocks/content/sidebar-card-image.html
+++ b/dist/blocks/content/sidebar-card-image.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/blocks/content/sidebar-card-person.html
+++ b/dist/blocks/content/sidebar-card-person.html
@@ -102,7 +102,7 @@
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-cta.html">Card--CTA</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-department.html">Card--Department</a></li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-details.html">Card--Details</a></li>
-              <li>Card--Downloads</li>
+              <li><a href="/hee-prototypes/blocks/content/sidebar-card-downloads.html">Card--Downloads</a></li>
               <li>Card--External Links</li>
               <li>Card--Internal Links</li>
               <li><a href="/hee-prototypes/blocks/content/sidebar-card-image.html">Card--Image</a></li>

--- a/dist/templates/examples/publications-item.html
+++ b/dist/templates/examples/publications-item.html
@@ -368,7 +368,7 @@
               <span>Estimated reading time:</span> 2 mins
             </div>
           </div>
-          <div class="hee-card hee-card--details">
+          <div class="hee-card hee-card--details hee-card--downloads">
             <h3>Alternative versions</h3>
             <div class="hee-card--details__item">
               <a class="hee-resources__link" href="#" title="Publication title - PDF version">
@@ -386,7 +386,7 @@
           hee-resources__xls"> XLS </span></a>
             </div>
           </div>
-          <div class="hee-card hee-card--details">
+          <div class="hee-card hee-card--details hee-card--downloads">
             <h3>Languages</h3>
             <div class="hee-card--details__item">
               <a class="hee-resources__link" href="#" title="Teitl y cyhoeddiad - Fersiwn PDF">


### PR DESCRIPTION
@sankar-shunmuga @smanivasag we currently have a new sidebar card for Publications items, which displays a list of resource downloads and their filetype:

![image](https://user-images.githubusercontent.com/8265949/214042796-8ce5812c-7662-4436-829b-e7acae7599f3.png)

Currently it is a combination of the `hee-resoures` link component, displayed within the new `card--details` components. This styles the card as expected as per Figma.

However we need this card to be it's own standalone component, which is what this PR covers.

Please shout if you have any questions :slightly_smiling_face: thanks!