### PR TITLE
[NWPS-1665] - Added aria-label attribute to Google Map macro

### DIFF
--- a/app/assets/hee/blocks/content/main/google-map/macro.njk
+++ b/app/assets/hee/blocks/content/main/google-map/macro.njk
@@ -1,5 +1,5 @@
 {% macro googleMap(params) %}
-<div class="hee-google-map">
+<div class="hee-google-map" aria-label="Google Map">
     <div class="hee-google-map__wrapper">
         {{ params.embedCode|safe }}
     </div>


### PR DESCRIPTION
@FranciscoRuizHEE this PR adds a missing `aria-label` attribute to the Google Map embed, making it more accessible and screen-reader friendly.

We'd need to update the FM template for this macro on the backend too.

Thanks :) 
