### PR TITLE
NWPS-1703 - Fixed alignment of publication title

### DIFF
--- a/app/assets/hee/blocks/content/main/hee-publication-doc/_publication-doc.scss
+++ b/app/assets/hee/blocks/content/main/hee-publication-doc/_publication-doc.scss
@@ -51,6 +51,7 @@
   }
 
   .hee-publication-doc__details {
+    align-self: flex-start;
     padding-left: map-get($nhsuk-spacing-points, 4);
 
     h3 {


### PR DESCRIPTION
@FranciscoRuizHEE this fixes a small bug regarding the alignment of the Publication title when there are no other details included.

**Before:**
![image](https://github.com/Health-Education-England/hee-prototypes/assets/8265949/74b233b4-69f9-4b8d-ad1d-92d935d15fd2)

**After:**
![image](https://github.com/Health-Education-England/hee-prototypes/assets/8265949/a33c1e7b-714c-47fe-9ab4-30c04b9f8044)
