### PR TITLE
Release: NWPS-1791 - Added logic to hide TOC via javascript when no headings

### DIFF
--- a/app/assets/hee/blocks/content/sidebar/hee-anchorlinks/toc.js
+++ b/app/assets/hee/blocks/content/sidebar/hee-anchorlinks/toc.js
@@ -20,6 +20,7 @@ export default () => {
       // Only attempt to build TOC links if H2 anchors found on page.
       let headings = document.querySelectorAll(this.containerSelector + ' ' + this.headingSelector);
       if (headings.length === 0) {
+        this.tableContents.hidden = true;
         return;
       }
 


### PR DESCRIPTION
@FranciscoRuizHEE small tweak to the TOC javascript to hide the block, when no headings are available on the page.

Our last official PR together! :smiling_face_with_tear: 