### PR TITLE
[NWPS-1783] Downloads card accessibility fixes

### DIFF
--- a/app/assets/hee/blocks/content/sidebar/hee-resources/macro.njk
+++ b/app/assets/hee/blocks/content/sidebar/hee-resources/macro.njk
@@ -16,6 +16,7 @@
   <a class="hee-resources__link"
      href="{{ params.url }}"
      title="{{ params.title }}"
+     aria-label="Download {{ params.title }} in {{ params.docType | safe }} format, {{ params.docSize | safe }}"
     {%- if params.newTab === true %}
       target="_blank"
     {%- endif %}

--- a/app/views/blocks/content/sidebar-card-downloads.html
+++ b/app/views/blocks/content/sidebar-card-downloads.html
@@ -97,7 +97,7 @@
 <div class="hee-card hee-card--details hee-card--downloads">
     <h3>Alternative versions</h3>
     <div class="hee-card--details__item">
-      <a class="hee-resources__link" href="#" title="First Publication Title">
+      <a class="hee-resources__link" href="#" title="First Publication Title" aria-label="Download Short title in PDF format, 836KB">
         <div class="hee-resources__wrapper">
           <span class="hee-resources__text">Short title</span><span class="hee-resources__docSize"> 836KB </span>
         </div><span class="hee-resources__tag
@@ -105,7 +105,7 @@
       </a>
     </div>
     <div class="hee-card--details__item">
-      <a class="hee-resources__link" href="#" title="Second Publication Title">
+      <a class="hee-resources__link" href="#" title="Second Publication Title" aria-label="Download Second Publication Title in ODF format, 1.4MB">
         <div class="hee-resources__wrapper">
           <span class="hee-resources__text"> Second Publication Title </span><span class="hee-resources__docSize"> 1.4MB </span>
         </div><span class="hee-resources__tag
@@ -113,7 +113,7 @@
       </a>
     </div>
     <div class="hee-card--details__item">
-      <a class="hee-resources__link" href="#" title="Third Publication Title">
+      <a class="hee-resources__link" href="#" title="Third Publication Title" aria-label="Download Third Publication Title in XLS format, 2.89MB">
         <div class="hee-resources__wrapper">
           <span class="hee-resources__text"> Third Publication Title </span><span class="hee-resources__docSize"> 2.89MB </span>
         </div><span class="hee-resources__tag

--- a/dist/blocks/content/examples/sidebar-card-downloads.html
+++ b/dist/blocks/content/examples/sidebar-card-downloads.html
@@ -38,7 +38,7 @@
   <div class="hee-card hee-card--details hee-card--downloads">
     <h3>Alternative versions</h3>
     <div class="hee-card--details__item">
-      <a class="hee-resources__link" href="#" title="Short title">
+      <a class="hee-resources__link" href="#" title="Short title" aria-label="Download Short title in PDF format, 836KB">
         <div class="hee-resources__wrapper">
           <span class="hee-resources__text"> Short title </span><span class="hee-resources__docSize"> 836KB </span>
         </div><span class="hee-resources__tag
@@ -46,7 +46,7 @@
       </a>
     </div>
     <div class="hee-card--details__item">
-      <a class="hee-resources__link" href="#" title="Second Publication Title">
+      <a class="hee-resources__link" href="#" title="Second Publication Title" aria-label="Download Second Publication Title in ODF format, 1.4MB">
         <div class="hee-resources__wrapper">
           <span class="hee-resources__text"> Second Publication Title </span><span class="hee-resources__docSize"> 1.4MB </span>
         </div><span class="hee-resources__tag
@@ -54,7 +54,7 @@
       </a>
     </div>
     <div class="hee-card--details__item">
-      <a class="hee-resources__link" href="#" title="Third Publication Title">
+      <a class="hee-resources__link" href="#" title="Third Publication Title" aria-label="Download Third Publication Title in XLS format, 2.89MB">
         <div class="hee-resources__wrapper">
           <span class="hee-resources__text"> Third Publication Title </span><span class="hee-resources__docSize"> 2.89MB </span>
         </div><span class="hee-resources__tag
@@ -62,7 +62,7 @@
       </a>
     </div>
     <div class="hee-card--details__item">
-      <a class="hee-resources__link" href="#" title="Fourth Publication Title">
+      <a class="hee-resources__link" href="#" title="Fourth Publication Title" aria-label="Download Fourth Publication Title in MRC format, 2.89MB">
         <div class="hee-resources__wrapper">
           <span class="hee-resources__text"> Fourth Publication Title </span><span class="hee-resources__docSize"> 2.89MB </span>
         </div><span class="hee-resources__tag

--- a/dist/blocks/content/sidebar-card-downloads.html
+++ b/dist/blocks/content/sidebar-card-downloads.html
@@ -179,7 +179,7 @@
 &lt;div class=&quot;hee-card hee-card--details hee-card--downloads&quot;&gt;
     &lt;h3&gt;Alternative versions&lt;/h3&gt;
     &lt;div class=&quot;hee-card--details__item&quot;&gt;
-      &lt;a class=&quot;hee-resources__link&quot; href=&quot;#&quot; title=&quot;First Publication Title&quot;&gt;
+      &lt;a class=&quot;hee-resources__link&quot; href=&quot;#&quot; title=&quot;First Publication Title&quot; aria-label=&quot;Download Short title in PDF format, 836KB&quot;&gt;
         &lt;div class=&quot;hee-resources__wrapper&quot;&gt;
           &lt;span class=&quot;hee-resources__text&quot;&gt;Short title&lt;/span&gt;&lt;span class=&quot;hee-resources__docSize&quot;&gt; 836KB &lt;/span&gt;
         &lt;/div&gt;&lt;span class=&quot;hee-resources__tag
@@ -187,7 +187,7 @@
       &lt;/a&gt;
     &lt;/div&gt;
     &lt;div class=&quot;hee-card--details__item&quot;&gt;
-      &lt;a class=&quot;hee-resources__link&quot; href=&quot;#&quot; title=&quot;Second Publication Title&quot;&gt;
+      &lt;a class=&quot;hee-resources__link&quot; href=&quot;#&quot; title=&quot;Second Publication Title&quot; aria-label=&quot;Download Second Publication Title in ODF format, 1.4MB&quot;&gt;
         &lt;div class=&quot;hee-resources__wrapper&quot;&gt;
           &lt;span class=&quot;hee-resources__text&quot;&gt; Second Publication Title &lt;/span&gt;&lt;span class=&quot;hee-resources__docSize&quot;&gt; 1.4MB &lt;/span&gt;
         &lt;/div&gt;&lt;span class=&quot;hee-resources__tag
@@ -195,7 +195,7 @@
       &lt;/a&gt;
     &lt;/div&gt;
     &lt;div class=&quot;hee-card--details__item&quot;&gt;
-      &lt;a class=&quot;hee-resources__link&quot; href=&quot;#&quot; title=&quot;Third Publication Title&quot;&gt;
+      &lt;a class=&quot;hee-resources__link&quot; href=&quot;#&quot; title=&quot;Third Publication Title&quot; aria-label=&quot;Download Third Publication Title in XLS format, 2.89MB&quot;&gt;
         &lt;div class=&quot;hee-resources__wrapper&quot;&gt;
           &lt;span class=&quot;hee-resources__text&quot;&gt; Third Publication Title &lt;/span&gt;&lt;span class=&quot;hee-resources__docSize&quot;&gt; 2.89MB &lt;/span&gt;
         &lt;/div&gt;&lt;span class=&quot;hee-resources__tag

--- a/dist/templates/examples/publications-item.html
+++ b/dist/templates/examples/publications-item.html
@@ -346,7 +346,7 @@
         <div class="hee-card hee-card--details hee-card--downloads">
           <h3>Alternative versions</h3>
           <div class="hee-card--details__item">
-            <a class="hee-resources__link" href="#" title="Short title">
+            <a class="hee-resources__link" href="#" title="Short title" aria-label="Download Short title in PDF format, 836KB">
               <div class="hee-resources__wrapper">
                 <span class="hee-resources__text"> Short title </span><span class="hee-resources__docSize"> 836KB </span>
               </div><span class="hee-resources__tag
@@ -354,7 +354,7 @@
             </a>
           </div>
           <div class="hee-card--details__item">
-            <a class="hee-resources__link" href="#" title="Second Publication Title">
+            <a class="hee-resources__link" href="#" title="Second Publication Title" aria-label="Download Second Publication Title in ODF format, 1.4MB">
               <div class="hee-resources__wrapper">
                 <span class="hee-resources__text"> Second Publication Title </span><span class="hee-resources__docSize"> 1.4MB </span>
               </div><span class="hee-resources__tag
@@ -362,7 +362,7 @@
             </a>
           </div>
           <div class="hee-card--details__item">
-            <a class="hee-resources__link" href="#" title="Third Publication Title">
+            <a class="hee-resources__link" href="#" title="Third Publication Title" aria-label="Download Third Publication Title in XLS format, 2.89MB">
               <div class="hee-resources__wrapper">
                 <span class="hee-resources__text"> Third Publication Title </span><span class="hee-resources__docSize"> 2.89MB </span>
               </div><span class="hee-resources__tag
@@ -370,7 +370,7 @@
             </a>
           </div>
           <div class="hee-card--details__item">
-            <a class="hee-resources__link" href="#" title="Fourth Publication Title">
+            <a class="hee-resources__link" href="#" title="Fourth Publication Title" aria-label="Download Fourth Publication Title in MRC format, 2.89MB">
               <div class="hee-resources__wrapper">
                 <span class="hee-resources__text"> Fourth Publication Title </span><span class="hee-resources__docSize"> 2.89MB </span>
               </div><span class="hee-resources__tag
@@ -381,7 +381,7 @@
         <div class="hee-card hee-card--details">
           <h3>Languages</h3>
           <div class="hee-card--details__item">
-            <a class="hee-resources__link" href="#" title="Teitl y cyhoeddiad">
+            <a class="hee-resources__link" href="#" title="Teitl y cyhoeddiad" aria-label="Download Teitl y cyhoeddiad in PDF format, ">
               <div class="hee-resources__wrapper">
                 <span class="hee-resources__text"> Teitl y cyhoeddiad </span>
               </div><span class="hee-resources__tag
@@ -389,7 +389,7 @@
             </a>
           </div>
           <div class="hee-card--details__item">
-            <a class="hee-resources__link" href="#" title="Tytuł publikacji">
+            <a class="hee-resources__link" href="#" title="Tytuł publikacji" aria-label="Download Tytuł publikacji in PDF format, ">
               <div class="hee-resources__wrapper">
                 <span class="hee-resources__text"> Tytuł publikacji </span>
               </div><span class="hee-resources__tag

--- a/dist/templates/examples/standard-content.html
+++ b/dist/templates/examples/standard-content.html
@@ -336,7 +336,7 @@
         <div class="hee-card hee-card--details hee-card--downloads">
           <h3>Alternative versions</h3>
           <div class="hee-card--details__item">
-            <a class="hee-resources__link" href="#" title="Short title">
+            <a class="hee-resources__link" href="#" title="Short title" aria-label="Download Short title in PDF format, 836KB">
               <div class="hee-resources__wrapper">
                 <span class="hee-resources__text"> Short title </span><span class="hee-resources__docSize"> 836KB </span>
               </div><span class="hee-resources__tag
@@ -344,7 +344,7 @@
             </a>
           </div>
           <div class="hee-card--details__item">
-            <a class="hee-resources__link" href="#" title="Second Publication Title">
+            <a class="hee-resources__link" href="#" title="Second Publication Title" aria-label="Download Second Publication Title in ODF format, 1.4MB">
               <div class="hee-resources__wrapper">
                 <span class="hee-resources__text"> Second Publication Title </span><span class="hee-resources__docSize"> 1.4MB </span>
               </div><span class="hee-resources__tag
@@ -352,7 +352,7 @@
             </a>
           </div>
           <div class="hee-card--details__item">
-            <a class="hee-resources__link" href="#" title="Third Publication Title">
+            <a class="hee-resources__link" href="#" title="Third Publication Title" aria-label="Download Third Publication Title in XLS format, 2.89MB">
               <div class="hee-resources__wrapper">
                 <span class="hee-resources__text"> Third Publication Title </span><span class="hee-resources__docSize"> 2.89MB </span>
               </div><span class="hee-resources__tag


### PR DESCRIPTION
Included an `aria-label` attribute for `Downloads card` links with a value in `Download ${docTitle} in ${docExtn} format, ${docSize}` format (e.g. `Download Short title in PDF format, 836KB`) [so that screen reader would read this out instead of the elements within the link].