### PR TITLE
[NWPS-1784] Publication landing page documents file icon accessibility improvement

### DIFF
--- a/app/assets/hee/blocks/content/main/hee-publication-doc/macro.njk
+++ b/app/assets/hee/blocks/content/main/hee-publication-doc/macro.njk
@@ -7,7 +7,7 @@
           <div class="hee-publication-doc__icon__corner__triangle"></div>
         </div>
       </div>
-      <div class="hee-publication-doc__icon__title">{{ item.type|upper }}</div>
+      <div class="hee-publication-doc__icon__title" aria-hidden="true">{{ item.type|upper }}</div>
     </div>
     <div class="hee-publication-doc__details">
       <h3><a href="{{ item.href }}">{{ item.title }}</a></h3>

--- a/dist/templates/examples/publications-landing.html
+++ b/dist/templates/examples/publications-landing.html
@@ -205,7 +205,7 @@
                   <div class="hee-publication-doc__icon__corner__triangle"></div>
                 </div>
               </div>
-              <div class="hee-publication-doc__icon__title">WEB</div>
+              <div class="hee-publication-doc__icon__title" aria-hidden="true">WEB</div>
             </div>
             <div class="hee-publication-doc__details">
               <h3><a href="#">Publication title - Web version</a></h3>
@@ -223,7 +223,7 @@
                   <div class="hee-publication-doc__icon__corner__triangle"></div>
                 </div>
               </div>
-              <div class="hee-publication-doc__icon__title">PDF</div>
+              <div class="hee-publication-doc__icon__title" aria-hidden="true">PDF</div>
             </div>
             <div class="hee-publication-doc__details">
               <h3><a href="#">Publication title - PDF version</a></h3>
@@ -241,7 +241,7 @@
                   <div class="hee-publication-doc__icon__corner__triangle"></div>
                 </div>
               </div>
-              <div class="hee-publication-doc__icon__title">ODT</div>
+              <div class="hee-publication-doc__icon__title" aria-hidden="true">ODT</div>
             </div>
             <div class="hee-publication-doc__details">
               <h3><a href="#">Publication title - Open Document version</a></h3>
@@ -259,7 +259,7 @@
                   <div class="hee-publication-doc__icon__corner__triangle"></div>
                 </div>
               </div>
-              <div class="hee-publication-doc__icon__title">XLSX</div>
+              <div class="hee-publication-doc__icon__title" aria-hidden="true">XLSX</div>
             </div>
             <div class="hee-publication-doc__details">
               <h3><a href="#">Publication title - Open Document version</a></h3>
@@ -278,7 +278,7 @@
                   <div class="hee-publication-doc__icon__corner__triangle"></div>
                 </div>
               </div>
-              <div class="hee-publication-doc__icon__title">PDF</div>
+              <div class="hee-publication-doc__icon__title" aria-hidden="true">PDF</div>
             </div>
             <div class="hee-publication-doc__details">
               <h3><a href="#">Teitl y cyhoeddiad - Fersiwn PDF</a></h3>
@@ -295,7 +295,7 @@
                   <div class="hee-publication-doc__icon__corner__triangle"></div>
                 </div>
               </div>
-              <div class="hee-publication-doc__icon__title">PDF</div>
+              <div class="hee-publication-doc__icon__title" aria-hidden="true">PDF</div>
             </div>
             <div class="hee-publication-doc__details">
               <h3><a href="#">Tytuł publikacji - wersja PDF</a></h3>


### PR DESCRIPTION
Added `aria-hidden="true"` to file icon title element (`<div class="hee-publication-doc__icon__title" aria-hidden="true">...</div>`) to instruct screen readers to ignore reading out the element, thanks